### PR TITLE
Fix bottleneck in EXD parsing

### DIFF
--- a/ironworks/src/file/exd.rs
+++ b/ironworks/src/file/exd.rs
@@ -2,7 +2,7 @@
 
 use std::io::{Cursor, Read, Seek};
 
-use binrw::{binread, until_eof, BinRead, BinResult, ReadOptions};
+use binrw::{binread, BinRead, BinResult, ReadOptions};
 use getset::{CopyGetters, Getters};
 
 use crate::{
@@ -26,9 +26,9 @@ pub struct ExcelData {
 	// unknown2: [u16; 10],
 	/// Vector of rows contained within this page.
 	#[br(
-    pad_before = 20,
-    count = index_size / RowDefinition::SIZE,
-  )]
+		pad_before = 20,
+		count = index_size / RowDefinition::SIZE,
+	)]
 	#[get = "pub"]
 	rows: Vec<RowDefinition>,
 
@@ -160,6 +160,12 @@ impl RowDefinition {
 
 fn current_position<R: Read + Seek>(reader: &mut R, _: &ReadOptions, _: ()) -> BinResult<u64> {
 	Ok(reader.stream_position()?)
+}
+
+fn until_eof<R: Read + Seek>(reader: &mut R, _: &ReadOptions, _: ()) -> BinResult<Vec<u8>> {
+	let mut v = Vec::new();
+	reader.read_to_end(&mut v)?;
+	Ok(v)
 }
 
 #[binread]


### PR DESCRIPTION
Reading rows from Excel Sheets turns out to be incredibly slow. This could be verified with this example:

```rust
use std::time::Instant;

use anyhow::Result;

use ironworks::{
    excel::{Excel, Language},
    sqpack::{Install, SqPack},
    Ironworks,
};

fn main() -> Result<()> {
    let start = Instant::now();
    let ironworks = Ironworks::new().with_resource(SqPack::new(Install::search().unwrap()));

    let excel = Excel::with().language(Language::English).build(&ironworks);

    for _ in excel.sheet("Item")?.iter() {}

    println!("Iteration of Items time: {:?}", start.elapsed());

    Ok(())
}
```

```
Iteration of Items time: 4.3175689s
```


After some digging into the problem, it looks like the `until_eof` parser was the cause of this bottleneck, so I replaced the implementation with my own.

Now the example runs quite a bit faster:

```
Iteration of Items time: 595.5406ms
```