### PR TITLE
Speed up finding row definition in ExcelData

### DIFF
--- a/ironworks/src/file/exd.rs
+++ b/ironworks/src/file/exd.rs
@@ -118,13 +118,23 @@ impl ExcelData {
 
 	fn row_meta(&self, row_id: u32) -> Result<(RowHeader, usize)> {
 		// Find the row definition for the requested row ID.
-		let row_definition = self.rows.iter().find(|row| row.id == row_id).ok_or({
-			Error::NotFound(ErrorValue::Row {
-				row: row_id,
-				subrow: 0,
-				sheet: None,
-			})
-		})?;
+		let row_definition = {
+			// In all likelihood the row can be found simply by indexing
+			// the vector based on the ID's offset from the first row.
+			let first_row_id = self.rows.get(0).map_or(0, |row| row.id);
+			let row_idx = (row_id - first_row_id) as usize;
+			if row_idx < self.rows.len() && self.rows[row_idx].id == row_id {
+				&self.rows[row_idx]
+			} else {
+				self.rows.iter().find(|row| row.id == row_id).ok_or({
+					Error::NotFound(ErrorValue::Row {
+						row: row_id,
+						subrow: 0,
+						sheet: None,
+					})
+				})?
+			}
+		};
 
 		// Get a cursor to the start of the row.
 		let mut cursor = Cursor::new(&self.data);


### PR DESCRIPTION
I recently decided to try reading out actions to a file and to my surprise it was also incredibly slow:

```rust
use std::time::Instant;

use anyhow::Result;

use ironworks::{
    excel::{Excel, Language},
    sqpack::{Install, SqPack},
    Ironworks,
};

fn main() -> Result<()> {
    let start = Instant::now();
    let ironworks = Ironworks::new().with_resource(SqPack::new(Install::search().unwrap()));

    let excel = Excel::with().language(Language::English).build(&ironworks);

    for _ in excel.sheet("Action")?.iter() {}

    println!("Iteration of Items time: {:?}", start.elapsed());

    Ok(())
}
```

```
Iteration of Actions time: 5.4842278s
```

After digging some more, I found out that Actions is not split into more than one page and that getting a single row from the page can take O(n) time.

Maybe this can be solved by parsing rows into a HashMap, but looking up the row index in the Vec directly based on its ID seems to work just fine in many cases too.

After this change, iteration time dramatically improves:
```
Iteration of Actions time: 261.9265ms
```

I also considered replacing the `find` with `binary_search_by_key` but it doesn't seem to improve anything much and I'm not sure if we can assume rows are already sorted.
